### PR TITLE
(fix): get form to update state

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -24,7 +24,7 @@ function App() {
   const handleChange = (e) => {
     console.log('Change event triggered for:', e.target.name, 'with value:', e.target.value);
     const { name, value } = e.target;
-    if (['volume', 'cost'].includes(name)) {
+    if (name.includes('current')) {
       const [prefix, type] = name.split('-');
       setFormData(prev => {
         const newState = {


### PR DESCRIPTION
The simplest fix for this seems to be to change the `if` statement within the `handleChange` handler such that it matches the correct portion of the state.

There are numerous other areas within the app that would need updating; include the 'unit' in the state, use proper types (numbers) for the data etc. - but I'm sure you're aware of these.